### PR TITLE
fix: ensure BatchedMesh is available during build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,34 @@
-import { defineConfig } from "vite";
+import { readFileSync } from "node:fs";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
+
+const ensureThreeBatchedMeshExport = (): Plugin => {
+  const threeModulePath = path
+    .resolve(__dirname, "node_modules/three/build/three.module.js")
+    .replace(/\\/g, "/");
+  const exportStatement =
+    "export { BatchedMesh } from '../examples/jsm/objects/BatchedMesh.js';";
+
+  return {
+    name: "ensure-three-batched-mesh-export",
+    enforce: "pre",
+    load(id) {
+      if (id.replace(/\\/g, "/") === threeModulePath) {
+        const original = readFileSync(threeModulePath, "utf-8");
+
+        if (original.includes(exportStatement)) {
+          return null;
+        }
+
+        return `${original}\n${exportStatement}\n`;
+      }
+
+      return null;
+    },
+  };
+};
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -10,6 +37,7 @@ export default defineConfig(({ mode }) => ({
     port: 8080,
   },
   plugins: [
+    ensureThreeBatchedMeshExport(),
     react(),
     mode === 'development' &&
     componentTagger(),


### PR DESCRIPTION
## Summary
- add a Vite plugin that augments three's ESM build with a BatchedMesh export
- ensure dependent tooling like three-mesh-bvh can resolve the class without bundler errors

## Testing
- npm run build
- npm run lint *(fails: existing repository-wide lint errors about explicit any, no-case-declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68d64f1a150c8331aafba3b8f1592bb3