### PR TITLE
fix: ensure three BatchedMesh export during prebundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,66 @@
-import { defineConfig } from "vite";
+import { readFileSync } from "node:fs";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
+import type { Plugin as EsbuildPlugin } from "esbuild";
+
+const normalizePath = (filePath: string) => filePath.replace(/\\/g, "/");
+const threeModulePath = normalizePath(
+  path.resolve(__dirname, "node_modules/three/build/three.module.js"),
+);
+const batchedMeshExportStatement =
+  "export { BatchedMesh } from '../examples/jsm/objects/BatchedMesh.js';";
+
+let cachedPatchedSource: string | null | undefined;
+
+const getPatchedThreeSource = () => {
+  if (cachedPatchedSource !== undefined) {
+    return cachedPatchedSource;
+  }
+
+  const original = readFileSync(threeModulePath, "utf-8");
+
+  cachedPatchedSource = original.includes(batchedMeshExportStatement)
+    ? null
+    : `${original}\n${batchedMeshExportStatement}\n`;
+
+  return cachedPatchedSource;
+};
+
+const ensureThreeBatchedMeshExport = (): Plugin => ({
+  name: "ensure-three-batched-mesh-export",
+  enforce: "pre",
+  load(id) {
+    if (normalizePath(id) !== threeModulePath) {
+      return null;
+    }
+
+    return getPatchedThreeSource();
+  },
+});
+
+const ensureThreeBatchedMeshExportEsbuild = (): EsbuildPlugin => ({
+  name: "ensure-three-batched-mesh-export",
+  setup(build) {
+    build.onLoad({ filter: /three\.module\.js$/ }, async (args) => {
+      if (normalizePath(args.path) !== threeModulePath) {
+        return undefined;
+      }
+
+      const patched = getPatchedThreeSource();
+
+      if (!patched) {
+        return undefined;
+      }
+
+      return {
+        contents: patched,
+        loader: "js",
+      };
+    });
+  },
+});
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -10,13 +69,25 @@ export default defineConfig(({ mode }) => ({
     port: 8080,
   },
   plugins: [
+    ensureThreeBatchedMeshExport(),
     react(),
-    mode === 'development' &&
-    componentTagger(),
+    mode === "development" && componentTagger(),
   ].filter(Boolean),
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      plugins: [ensureThreeBatchedMeshExportEsbuild()],
+    },
+  },
+  ssr: {
+    optimizeDeps: {
+      esbuildOptions: {
+        plugins: [ensureThreeBatchedMeshExportEsbuild()],
+      },
     },
   },
 }));


### PR DESCRIPTION
## Summary
- cache a patched variant of three's ESM bundle that re-exports BatchedMesh
- register matching Vite and esbuild plugins so optimizeDeps and SSR prebundles receive the augmented module
- keep the component tagger limited to development mode with consistent quoting

## Testing
- npm run build
- npm run lint *(fails: numerous pre-existing lint errors about explicit any, no-case-declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68d64f1a150c8331aafba3b8f1592bb3